### PR TITLE
Add homework notebooks for visualization lessons

### DIFF
--- a/3-Data-Visualization/Homework/09-visualization-quantities-homework.ipynb
+++ b/3-Data-Visualization/Homework/09-visualization-quantities-homework.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing Quantities - Homework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `birds.csv` dataset to practice plotting quantities."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\nimport matplotlib.pyplot as plt\nbirds = pd.read_csv('../data/birds.csv')\nbirds.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: scatter plot of wingspan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10,4))\nplt.title('Max Wingspan in Centimeters')\nplt.ylabel('Wingspan (CM)')\nplt.tick_params(axis='x',labelbottom=False)\nfor i in range(len(birds)):\n    plt.plot(birds['Name'][i], birds['MaxWingspan'][i], 'bo')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Plot `MaxBodyMass` against the bird names in a similar scatter plot."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: number of birds by category"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "category_count = birds['Category'].value_counts()\ncategory_count.plot.barh()\nplt.title('Bird Categories')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Show the number of birds per `Order` using a horizontal bar chart."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/3-Data-Visualization/Homework/10-visualization-distributions-homework.ipynb
+++ b/3-Data-Visualization/Homework/10-visualization-distributions-homework.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing Distributions - Homework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the same `birds.csv` dataset, explore distributions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\nimport matplotlib.pyplot as plt\nbirds=pd.read_csv('../data/birds.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: histogram of `MaxBodyMass`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "birds['MaxBodyMass'].plot(kind='hist',bins=30,figsize=(8,4))\nplt.title('Distribution of Max Body Mass')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Build a histogram showing the distribution of `MaxLength`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: 2D histogram comparing mass and length."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "plt.hist2d(birds['MaxBodyMass'], birds['MaxLength'])\nplt.xlabel('Max Body Mass')\nplt.ylabel('Max Length')\nplt.title('Mass vs Length')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Create a 2D histogram for `MaxWingspan` versus `MaxLength`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/3-Data-Visualization/Homework/11-visualization-proportions-homework.ipynb
+++ b/3-Data-Visualization/Homework/11-visualization-proportions-homework.ipynb
@@ -1,0 +1,109 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing Proportions - Homework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will use `mushrooms.csv` to practice proportion charts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\nimport matplotlib.pyplot as plt\nmushrooms=pd.read_csv('../data/mushrooms.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: pie chart of poisonous vs edible classes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "edibleclass=mushrooms.groupby('class').count()\nlabels=['Edible','Poisonous']\nplt.pie(edibleclass['population'],labels=labels,autopct='%.1f %%')\nplt.title('Edible?')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Create a pie chart showing distribution of mushroom `odor`.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: donut chart of habitats."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "habitat=mushrooms.groupby('habitat').count()\nlabels=habitat.index.tolist()\nplt.pie(habitat['class'],labels=labels,autopct='%1.1f%%',pctdistance=0.85)\ncenter_circle=plt.Circle((0,0),0.40,fc='white')\nfig=plt.gcf();fig.gca().add_artist(center_circle)\nplt.title('Mushroom Habitats')\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Display a donut chart for `ring-type` values."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: waffle chart of cap colors."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from pywaffle import Waffle\ncapcolor=mushrooms.groupby('cap-color').count()\ndata={'color':capcolor.index.tolist(),'amount':capcolor['class']}\ndf=pd.DataFrame(data)\nfig=plt.figure(FigureClass=Waffle,rows=10,values=df.amount,labels=list(df.color),figsize=(12,8))\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Build a waffle chart showing the distribution of `cap-shape`.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/3-Data-Visualization/Homework/12-visualization-relationships-homework.ipynb
+++ b/3-Data-Visualization/Homework/12-visualization-relationships-homework.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Visualizing Relationships - Homework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Use the `honey.csv` dataset to explore relationships between variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\nimport matplotlib.pyplot as plt\nimport seaborn as sns\nhoney=pd.read_csv('../data/honey.csv')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: scatter plot of price per pound vs state colored by year."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sns.relplot(x='priceperlb', y='state', hue='year', data=honey, height=6)\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Scatter plot `totalprod` vs state with hue set to year."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example: line chart of price per pound over time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "sns.relplot(x='year', y='priceperlb', kind='line', data=honey)\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Create a line chart showing `yieldpercol` across years."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/3-Data-Visualization/Homework/13-meaningful-visualizations-homework.ipynb
+++ b/3-Data-Visualization/Homework/13-meaningful-visualizations-homework.ipynb
@@ -1,0 +1,47 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Creative Visualizations - Homework"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Explore `letters.json` from the Dangerous Liaisons project and visualize the correspondence network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import json\nimport networkx as nx\nimport matplotlib.pyplot as plt\nwith open('../13-meaningful-visualizations/starter/src/assets/letters.json') as f:\n    letters=json.load(f)\nG=nx.DiGraph()\nfor l in letters:\n    G.add_edge(l['from'], l['to'])\nplt.figure(figsize=(8,8))\nnx.draw_networkx(G, with_labels=True, node_size=500, font_size=8)\nplt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Task:** Adjust node size based on how many letters each character sends."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## Summary
- add `Homework` directory for Data Visualization module
- create example notebooks for quantities, distributions, proportions, relationships, and creative visualizations
- each notebook includes tutorial code and extra tasks using the same datasets

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6883710eea60832da443c241fb7cf962